### PR TITLE
Update get_volumes if statement to use greater than instead of equals

### DIFF
--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -391,7 +391,7 @@ function get_volumes() {
   # Get PVC/PV for the pod
   log "Getting Pod: ${POD_NAME} to determine PVC names"
   VOLUMES_CLAIMS=$(kubectl get pod "$POD_NAME" -n "${NAMESPACE}" -ojsonpath='{range .spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}') # Get PVC Names
-  if [[ "${#VOLUMES_CLAIMS[@]}" -eq 0 ]]; then
+  if [[ "${#VOLUMES_CLAIMS[@]}" -gt 0 ]]; then
     for claim in "${VOLUMES_CLAIMS[@]}"; do
       get_object pvc "$claim"
       local PVC=$OBJECT


### PR DESCRIPTION
*Issue #, if available:*
Currently the `get_volumes` function finds PVCs attached to the pod then runs an if statement which checks if the count is equal to 0, effectively making the function useless since it will only run when there are no PVCs. See [here](https://github.com/aws-samples/eks-pod-information-collector/blob/110699f437abe9218d0498ba7aa54e3f2128a81c/eks-pod-information-collector.sh#L394).

*Description of changes:*
I modified the if statement to use greater than so this runs when the value is 1 or more. Tested this and it is now able to retrieve PVC information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
