### PR TITLE
Add support for Karpenter to EPIC collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/aws-samples/eks-pod-information-collector/actions/workflows/CI.yml/badge.svg?branch=dev)](https://github.com/aws-samples/eks-pod-information-collector/actions/workflows/CI.yml)
+[![CI](https://github.com/aws-samples/eks-pod-information-collector/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/aws-samples/eks-pod-information-collector/actions/workflows/CI.yml)
 
 ##  EKS Pod Information Collector (EPIC)
 

--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -473,18 +473,18 @@ function get_karpenter() {
   OUTPUT_DIR="${OUTPUT_DIR_NAME}/karpenter"
   mkdir "$OUTPUT_DIR"
 
-  local KARPENTER_MANIFEST
-  KARPENTER_MANIFEST=$(kubectl get deployment -n karpenter -l app.kubernetes.io/name=karpenter -ojsonpath='{.items}')
-  if [[ -n $KARPENTER_MANIFEST ]]; then
+  local KARPENTER
+  KARPENTER=$(kubectl get deployment -n kube-system -l app.kubernetes.io/name=karpenter -ojsonpath='{.items[*].metadata.name}')
+  if [[ -n $KARPENTER ]]; then
     log -p "Collecting information related to Karpenter"
 
     log "Getting Karpenter deployment logs of all containers"
     KARPENTER_LOG_FILE=$(get_filename "karpenter" "log")
-    kubectl logs -l app.kubernetes.io/name=karpenter -n karpenter --all-containers --tail=-1 > "${KARPENTER_LOG_FILE}"
+    kubectl logs -l app.kubernetes.io/name=karpenter -n kube-system --all-containers --tail=-1 > "${KARPENTER_LOG_FILE}"
 
     log "Getting Karpenter deployment"
     KARPENTER_DEPLOY_FILE=$(get_filename "karpenter_deployment" "json")
-    echo ${KARPENTER_MANIFEST} > ${KARPENTER_DEPLOY_FILE}
+    kubectl get deployment -n kube-system -l app.kubernetes.io/name=karpenter -ojsonpath='{.items}' > ${KARPENTER_DEPLOY_FILE}
 
     log "Get Karpenter NodePool"
     KARPENTER_NODEPOOL_FILE=$(get_filename "karpenter_nodepool" "yaml")

--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -468,6 +468,16 @@ function get_volumes() {
   fi
 }
 
+function find_namespace() {
+  # Takes a kind and name and finds the namespace of the given object, then prints it out
+  local KIND=$1
+  local NAME=$2
+  local NS
+
+  NS=$(kubectl get "${KIND}" --all-namespaces -o jsonpath="{.items[?(@.metadata.name==\"${NAME}\")].metadata.namespace}")
+  echo "${NS}"
+}
+
 function finalize() {
   prompt "Please type \"Yes\" and press ENTER if you want to archive the collected information, To Skip just press ENTER"
   read -t 30 -rep $'Do you want to create a Tarball of the collected information?\n>' CREATE_TAR

--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -476,26 +476,21 @@ function get_karpenter() {
   local KARPENTER
   KARPENTER=$(kubectl get deployment -n kube-system -l app.kubernetes.io/name=karpenter -ojsonpath='{.items[*].metadata.name}')
   if [[ -n $KARPENTER ]]; then
-    log -p "Collecting information related to Karpenter"
-
+    log -p "Collecting Karpenter deployment information & logs"
     log "Getting Karpenter deployment logs of all containers"
     KARPENTER_LOG_FILE=$(get_filename "karpenter" "log")
     kubectl logs -l app.kubernetes.io/name=karpenter -n kube-system --all-containers --tail=-1 > "${KARPENTER_LOG_FILE}"
-
     log "Getting Karpenter deployment"
     KARPENTER_DEPLOY_FILE=$(get_filename "karpenter_deployment" "json")
     kubectl get deployment -n kube-system -l app.kubernetes.io/name=karpenter -ojsonpath='{.items}' > ${KARPENTER_DEPLOY_FILE}
-
-    log "Get Karpenter NodePool"
+    log "Getting Karpenter NodePool"
     KARPENTER_NODEPOOL_FILE=$(get_filename "karpenter_nodepool" "yaml")
     kubectl get nodepool -o yaml >> "${KARPENTER_NODEPOOL_FILE}"
-
-    log "Get Karpenter EC2 NodeClass"
-    KARPENTER_EC2NODECLASS_FILE=$(get_filename "karpenter-ec2nodeclass" "yaml")
+    log "Getting Karpenter EC2 NodeClass"
+    KARPENTER_EC2NODECLASS_FILE=$(get_filename "karpenter_ec2nodeclass" "yaml")
     kubectl get ec2nodeclass -o yaml >> "${KARPENTER_EC2NODECLASS_FILE}"
-
-    log "Get Karpenter NodeClaim"
-    KARPENTER_NODECLAIM_FILE=$(get_filename "karpenter-nodeclaim" "yaml")
+    log "Getting Karpenter NodeClaim"
+    KARPENTER_NODECLAIM_FILE=$(get_filename "karpenter_nodeclaim" "yaml")
     kubectl get nodeclaim -o yaml >> "${KARPENTER_NODECLAIM_FILE}"
   fi
 }

--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -468,16 +468,6 @@ function get_volumes() {
   fi
 }
 
-function find_namespace() {
-  # Takes a kind and name and finds the namespace of the given object, then prints it out
-  local KIND=$1
-  local NAME=$2
-  local NS
-
-  NS=$(kubectl get "${KIND}" --all-namespaces -o jsonpath="{.items[?(@.metadata.name==\"${NAME}\")].metadata.namespace}")
-  echo "${NS}"
-}
-
 function get_karpenter() {
   # Checks if Karpenter exists in the cluster and grabs required information from it
   OUTPUT_DIR="${OUTPUT_DIR_NAME}/karpenter"

--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -491,7 +491,7 @@ function get_karpenter() {
     kubectl logs -l app.kubernetes.io/name=karpenter -n "${NS}" --all-containers --tail=-1 > "${KARPENTER_LOG_FILE}"
     log "Getting Karpenter deployment"
     KARPENTER_DEPLOY_FILE=$(get_filename "karpenter_deployment" "json")
-    kubectl get deployment -n "${NS}" -l app.kubernetes.io/name=karpenter -ojsonpath='{.items}' > ${KARPENTER_DEPLOY_FILE}
+    kubectl get deployment -n "${NS}" -l app.kubernetes.io/name=karpenter -ojsonpath='{.items}' > "${KARPENTER_DEPLOY_FILE}"
     log "Getting Karpenter NodePool"
     KARPENTER_NODEPOOL_FILE=$(get_filename "karpenter_nodepool" "yaml")
     kubectl get nodepool -o yaml >> "${KARPENTER_NODEPOOL_FILE}"
@@ -503,7 +503,6 @@ function get_karpenter() {
     kubectl get nodeclaim -o yaml >> "${KARPENTER_NODECLAIM_FILE}"
   fi
 }
-
 
 function finalize() {
   prompt "Please type \"Yes\" and press ENTER if you want to archive the collected information, To Skip just press ENTER"


### PR DESCRIPTION
*Issue #, if available:*
Currently EPIC collector doesn't grab information on Karpenter deployments.

*Description of changes:*
Added a function to grab relevant Karpenter information, checks for resources in `kube-system` and `karpenter` namespaces

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
