### PR TITLE
fix POD_OWNER_NAME declaration

### DIFF
--- a/eks-pod-information-collector.sh
+++ b/eks-pod-information-collector.sh
@@ -332,13 +332,12 @@ function get_pod() {
 
   log "Identifying Owner References of Pod: \"${POD_NAME}\""
   POD_OWNER_KIND=$(echo "$POD" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"kind": "\(.*\)".*/\1/p' | sed 's/".*//')
-  POD_OWNER_NAME=$(echo "$POD" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"kind": "\(.*\)".*"name": "\(.*\)", "uid":.*/\2/p' | sed 's/".*//')
-
+  POD_OWNER_NAME=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"name": "\(.*\)".*/\1/p' | sed 's/".*//')
   while [ ! "${POD_OWNER_KIND}" == '' ]; do
     get_object "$POD_OWNER_KIND" "$POD_OWNER_NAME"
     local OWNER=$OBJECT
     POD_OWNER_KIND=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"kind": "\(.*\)".*/\1/p' | sed 's/".*//')
-    POD_OWNER_NAME=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"kind": "\(.*\)".*"name": "\(.*\)", "uid":.*/\2/p' | sed 's/".*//')
+    POD_OWNER_NAME=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"name": "\(.*\)".*/\1/p' | sed 's/".*//')
   done
 
   # Get Service Account details


### PR DESCRIPTION
To correctly retrieve the **ownerReference** resource name, [lines 335 and 341](https://github.com/aws-samples/eks-pod-information-collector/blob/d3fef8378111d0060d08d8632b4f47aa2dedac51/eks-pod-information-collector.sh#L335) should be modified as follows:

---

#### Before

`POD_OWNER_NAME=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"kind": "\(.*\)".*"name": "\(.*\)", "uid":.*/\2/p' | sed 's/".*//') `

#### After

`POD_OWNER_NAME=$(echo "$OWNER" | sed -n '/"ownerReferences"/,/^[[:space:]]*}/ s/.*"name": "\(.*\)".*/\1/p' | sed 's/".*//')`

---

close #19 